### PR TITLE
add orchestrator info calls & fix non-json Content-type response

### DIFF
--- a/silverpeak/silverpeak.py
+++ b/silverpeak/silverpeak.py
@@ -659,6 +659,7 @@ class Silverpeak(object):
         """
         Update deployment config of appliance
         :param applianceID: The node ID of the appliance
+        :param deploymentData: Deployment configuration data
         :return: Result named tuple
         """
         url = '{}/appliance/rest/{}/deployment'.format(

--- a/silverpeak/silverpeak.py
+++ b/silverpeak/silverpeak.py
@@ -722,7 +722,7 @@ class Silverpeak(object):
 
     def post_interface_labels(self, interfaceLabelsData, deleteDependencies=None):
         """
-        Interface labels will be saved, completely replacing the current implementation.
+        Save interface labels, completely replacing the current implementation.
         You cannot remove labels that are in use in an overlay
         :param interfaceLabelsData: Object of labels (in json) to save
         (will overwrite the current lan labels list). To remove a label, set the 'active' to false
@@ -749,7 +749,7 @@ class Silverpeak(object):
 
     def get_gms_server_info(self):
         """
-        Returns orchestrator server information such as used disk space, hostname, release, etc...
+        Get orchestrator server information such as used disk space, hostname, release, etc...
         :return: Result named tuple
         """
 
@@ -759,7 +759,7 @@ class Silverpeak(object):
 
     def get_gms_server_brief_info(self):
         """
-        Returns orchestrator server information such as used disk space, hostname, release, etc...
+        Get orchestrator server information such as used disk space, hostname, release, etc...
         :return: Result named tuple
         """
 

--- a/silverpeak/silverpeak.py
+++ b/silverpeak/silverpeak.py
@@ -746,3 +746,13 @@ class Silverpeak(object):
             data=interfaceLabelsData,
             timeout=self.timeout
         )
+
+    def get_gms_server_info(self):
+        """
+        Returns orchestrator server information such as used disk space, hostname, release, etc...
+        :return: Result named tuple
+        """
+
+        url = '{}/gmsserver/info'.format(self.base_url)
+
+        return self._get(self.session, url)

--- a/silverpeak/silverpeak.py
+++ b/silverpeak/silverpeak.py
@@ -718,3 +718,30 @@ class Silverpeak(object):
             url += '?active=' + str(active).lower()
 
         return self._get(self.session, url)
+
+    def post_interface_labels(self, interfaceLabelsData, deleteDependencies=None):
+        """
+        Interface labels will be saved, completely replacing the current implementation.
+        You cannot remove labels that are in use in an overlay
+        :param interfaceLabelsData: Object of labels (in json) to save
+        (will overwrite the current lan labels list). To remove a label, set the 'active' to false
+        :param deleteDependencies: Boolean flag whether or not you want to delete the labels from port profiles
+        and templates using it.
+        :return: Result named tuple
+        """
+
+        url = '{}/gms/interfaceLabels'.format(self.base_url)
+
+        if deleteDependencies is not None:
+            if deleteDependencies:
+                url += '?deleteDependencies=true'
+            else:
+                url += '?deleteDependencies=false'
+
+        return self._post(
+            session=self.session,
+            url=url,
+            headers={'Content-Type': 'application/json'},
+            data=interfaceLabelsData,
+            timeout=self.timeout
+        )

--- a/silverpeak/silverpeak.py
+++ b/silverpeak/silverpeak.py
@@ -701,18 +701,19 @@ class Silverpeak(object):
             data=portForwardingData,
         )
 
-    def get_interface_labels(self, active=None, label_type=None):
+    def get_interface_labels(self, active=None, labelType=None):
         """
         Get all the interface labels saved
-        :param label_type: Optional, Type of interface that you want to retrieve the list of labels of [wan, lan]
-        :param active: Optional, Boolean flag to return only the active (active = true) or only inactive (active = false)
+        :param labelType: Optional, Type of interface that you want to retrieve the list of labels of [wan, lan]
+        :param active: Optional, Boolean flag to return only the active (active = true) or
+        only inactive (active = false)
         :return: Result named tuple
         """
 
         url = '{}/gms/interfaceLabels'.format(self.base_url)
 
-        if label_type:
-            url += '/' + label_type
+        if labelType:
+            url += '/' + labelType
 
         if active is not None:
             url += '?active=' + str(active).lower()

--- a/silverpeak/silverpeak.py
+++ b/silverpeak/silverpeak.py
@@ -499,7 +499,6 @@ class Silverpeak(object):
         """
         Configure Boost on an appliance
         :param applianceID: The node ID of the appliance
-        :param mini: enable or disable the mini license
         :param plus: enable or disable the plus license
         :param boost: enable or disable the boost license
         :param boostBandwidth: choose bandwidth to boost by

--- a/silverpeak/silverpeak.py
+++ b/silverpeak/silverpeak.py
@@ -712,7 +712,7 @@ class Silverpeak(object):
 
         url = '{}/gms/interfaceLabels'.format(self.base_url)
 
-        if labelType:
+        if labelType is not None:
             url += '/' + labelType
 
         if active is not None:

--- a/silverpeak/silverpeak.py
+++ b/silverpeak/silverpeak.py
@@ -756,3 +756,13 @@ class Silverpeak(object):
         url = '{}/gmsserver/info'.format(self.base_url)
 
         return self._get(self.session, url)
+
+    def get_gms_server_brief_info(self):
+        """
+        Returns orchestrator server information such as used disk space, hostname, release, etc...
+        :return: Result named tuple
+        """
+
+        url = '{}/gmsserver/briefInfo'.format(self.base_url)
+
+        return self._get(self.session, url)

--- a/silverpeak/silverpeak.py
+++ b/silverpeak/silverpeak.py
@@ -480,9 +480,11 @@ class Silverpeak(object):
         url = '{}/appliance/rest/{}/reboot'.format(self.base_url, applianceID)
 
         if factoryReset is None:
-            data = '{"reboot_type":"Normal","save_db":true,"clear_nm":false,"next_partition":false,"empty_db":false,"empty_db_err":false,"delay":0}'
+            data = '{"reboot_type":"Normal","save_db":true,"clear_nm":false,' \
+                   '"next_partition":false,"empty_db":false,"empty_db_err":false,"delay":0}'
         else:
-            data = '{"reboot_type":"Normal","save_db":true,"clear_nm":false,"next_partition":false,"empty_db":false,"empty_db_err":false,"delay":0,"reset_factory":true,"support_bypass":false}'
+            data = '{"reboot_type":"Normal","save_db":true,"clear_nm":false,"next_partition":false,' \
+                   '"empty_db":false,"empty_db_err":false,"delay":0,"reset_factory":true,"support_bypass":false}'
 
         return self._post(
             session=self.session,

--- a/silverpeak/silverpeak.py
+++ b/silverpeak/silverpeak.py
@@ -788,3 +788,13 @@ class Silverpeak(object):
         url = '{}/gmsOperatingSystem'.format(self.base_url)
 
         return self._get(self.session, url)
+
+    def get_gms_server_to_say_hello(self):
+        """
+        Get hello message
+        :return: Result named tuple
+        """
+
+        url = '{}/gmsserver/hello'.format(self.base_url)
+
+        return self._get(self.session, url)

--- a/silverpeak/silverpeak.py
+++ b/silverpeak/silverpeak.py
@@ -36,8 +36,10 @@ def parse_http_success(response):
     if response.request.method in ['GET']:
         reason = HTTP_RESPONSE_CODES[response.status_code]
         error = ''
-        if response.json():
+        if 'json' in response.headers.get('Content-Type'):
             json_response = response.json()
+        elif 'text' in response.headers.get('Content-Type'):
+            json_response = response.text
         else:
             json_response = dict()
             reason = HTTP_RESPONSE_CODES[response.status_code]

--- a/silverpeak/silverpeak.py
+++ b/silverpeak/silverpeak.py
@@ -766,3 +766,13 @@ class Silverpeak(object):
         url = '{}/gmsserver/briefInfo'.format(self.base_url)
 
         return self._get(self.session, url)
+
+    def get_gms_versions(self):
+        """
+        Get available orchestrator versions
+        :return: Result named tuple
+        """
+
+        url = '{}/gms/versions'.format(self.base_url)
+
+        return self._get(self.session, url)

--- a/silverpeak/silverpeak.py
+++ b/silverpeak/silverpeak.py
@@ -700,3 +700,21 @@ class Silverpeak(object):
             headers={'Content-Type': 'application/json'},
             data=portForwardingData,
         )
+
+    def get_interface_labels(self, active=None, label_type=None):
+        """
+        Get all the interface labels saved
+        :param label_type: Optional, Type of interface that you want to retrieve the list of labels of [wan, lan]
+        :param active: Optional, Boolean flag to return only the active (active = true) or only inactive (active = false)
+        :return: Result named tuple
+        """
+
+        url = '{}/gms/interfaceLabels'.format(self.base_url)
+
+        if label_type:
+            url += '/' + label_type
+
+        if active is not None:
+            url += '?active=' + str(active).lower()
+
+        return self._get(self.session, url)

--- a/silverpeak/silverpeak.py
+++ b/silverpeak/silverpeak.py
@@ -776,3 +776,13 @@ class Silverpeak(object):
         url = '{}/gms/versions'.format(self.base_url)
 
         return self._get(self.session, url)
+
+    def get_gms_operating_system(self):
+        """
+        Get orchestrator operating system type
+        :return: Result named tuple
+        """
+
+        url = '{}/gmsOperatingSystem'.format(self.base_url)
+
+        return self._get(self.session, url)

--- a/silverpeak/silverpeak.py
+++ b/silverpeak/silverpeak.py
@@ -333,7 +333,7 @@ class Silverpeak(object):
 
     def get_discovered(self):
         """
-        Reurns all the discovered appliances
+        Returns all the discovered appliances
         :return: Result named tuple
         """
         url = '{}/appliance/discovered'.format(self.base_url)
@@ -342,7 +342,7 @@ class Silverpeak(object):
 
     def get_approved(self):
         """
-        Reurns all approved appliances
+        Returns all approved appliances
         :return: Result named tuple
         """
         url = '{}/appliance/approved'.format(self.base_url)
@@ -351,7 +351,7 @@ class Silverpeak(object):
 
     def get_denied(self):
         """
-        Reurns all the denied appliances
+        Returns all the denied appliances
         :return: Result named tuple
         """
         url = '{}/appliance/denied'.format(self.base_url)
@@ -360,7 +360,7 @@ class Silverpeak(object):
 
     def get_interfaces(self, applianceID, cashed='true'):
         """
-        Reurns node configuration data from orchestrator database or from the specified appliance
+        Returns node configuration data from orchestrator database or from the specified appliance
         :param applianceID: The node ID of the appliance
         :param cashed: True/false Get from orchestrator/get from appliance
         :return: Result named tuple
@@ -400,8 +400,8 @@ class Silverpeak(object):
 
     def get_alarms(self, view='all', severity=''):
         """
-        Reurns active, historical, or all alarms for appliances whos id's are provided in the request body
-        :param view: Filters arams by active, closed, all
+        Returns active, historical, or all alarms for appliances whos id's are provided in the request body
+        :param view: Filters alarms by active, closed, all
         :param severity: Filters alarms by severity (warning, minor, major, critical)
         :return: Result named tuple
         """


### PR DESCRIPTION
Closes issue #33. 

While working on those calls, I stumbled on a JSONDecodeError when the response Content-type was not json. Used [this](https://github.com/psf/requests/issues/4908#issuecomment-446991562) solution to assure response is in json before trying to parse it. Then added condition to parse text Content-Type. 

Fixed some typos, shortened some lines, and removed unused param docstring.